### PR TITLE
reset body cursor on request copy as it breaks transmission

### DIFF
--- a/httpsig.go
+++ b/httpsig.go
@@ -69,6 +69,7 @@ func NewSignTransport(transport http.RoundTripper, opts ...signOption) http.Roun
 
 			if n != 0 {
 				r.Body = io.NopCloser(bytes.NewReader(b.Bytes()))
+				nr.Body = io.NopCloser(bytes.NewReader(b.Bytes()))
 			}
 		}
 


### PR DESCRIPTION
NewSignTransport() begins by cloning a request so it works on a copy of the original request but when reading the body into a bytes buffer, the cursor from both requests moves forward (I didn't get a chance to deep dive into this but it behaves like it's cloning a pointer to a region that's resized, proven by writing experimental code that shows the body is consumed on both requests regardless of which one is being read).

This causes an issue whenever trying to sign a request containing a body as the Content-Length header will present the original body size, but after the b.ReadFrom() call the remaining body size to read will be 0, causing a mismatch and a panic:

http: ContentLength=36 with Body length 0

A quick fix is to use the io.NopCloser() on the request clone too, making sure both requests are reset.

PS: do we really need to clone the request ?
