### PR TITLE
Use raw signature-params instead of self-construct one.

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -14,6 +14,7 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -59,6 +60,7 @@ func (v *verifier) Verify(msg *message) error {
 	// on algorithm
 	var sigID string
 	var params *signatureParams
+	var paramsRaw string
 	for _, p := range paramParts {
 		pParts := strings.SplitN(p, "=", 2)
 		if len(pParts) != 2 {
@@ -73,6 +75,7 @@ func (v *verifier) Verify(msg *message) error {
 		if _, ok := v.keys[candidate.keyID]; ok {
 			sigID = pParts[0]
 			params = candidate
+			paramsRaw = pParts[1]
 			break
 		}
 	}
@@ -140,12 +143,9 @@ func (v *verifier) Verify(msg *message) error {
 			return err
 		}
 	}
+	fmt.Fprintf(&b, "\"@signature-params\": %s", paramsRaw)
 
 	if _, err := verifier.w.Write(b.Bytes()); err != nil {
-		return err
-	}
-
-	if err = canonicalizeSignatureParams(verifier.w, params); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Currently the verifier uses a self-constructed "@signature-params" when verifying the signature. However, the order of signature params is not strictly defined in the standard.

For example, the following example is given in [Section 2.3](https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-19.html#name-signature-parameters) of revision 19.
```
("@target-uri" "@authority" "date" "cache-control")\
  ;keyid="test-key-rsa-pss";alg="rsa-pss-sha512";\
  created=1618884475;expires=1618884775
```

Next example is generated by Python library `requests-http-signature`.
```
("@method" "@authority" "@path" "@query" "content-digest" "date");created=1692263726;keyid="d8676596-40a7-4e1d-95fa-fa375147b65c";expires=1692263786;alg="hmac-sha256"
```

Both of them are valid, but will fail our verification. So I suggest we can just use the raw params data to compose the signable.