### PR TITLE
Add a public signer/verifier interface for some common scenarios.

### DIFF
--- a/httpsig.go
+++ b/httpsig.go
@@ -87,6 +87,14 @@ func (s *Signer) Sign(r *http.Request) error {
 	return nil
 }
 
+type VerifyingKey interface {
+	Verify(data []byte, signature []byte) error
+}
+
+type VerifyingKeyResolver interface {
+	Resolve(keyID string) VerifyingKey
+}
+
 type Verifier struct {
 	verifier
 }
@@ -217,6 +225,12 @@ func WithHeaders(hdr ...string) signOption {
 	// TODO: use this to implement required headers in verify?
 	return &optImpl{
 		s: func(s *signer) { s.headers = hdr },
+	}
+}
+
+func WithVerifyingKeyResolver(resolver VerifyingKeyResolver) verifyOption {
+	return &optImpl{
+		v: func(v *verifier) { v.resolver = resolver },
 	}
 }
 

--- a/sign.go
+++ b/sign.go
@@ -163,8 +163,8 @@ func signEccP256(pk *ecdsa.PrivateKey) sigHolder {
 }
 
 func signHmacSha256(secret []byte) sigHolder {
-	// TODO: add alg description
 	return sigHolder{
+		alg: "hmac-sha256",
 		signer: func() sigImpl {
 			h := hmac.New(sha256.New, secret)
 

--- a/standard_test.go
+++ b/standard_test.go
@@ -96,7 +96,7 @@ func TestVerify_B_2_1(t *testing.T) {
 	req.Header.Set("Signature-Input", `sig1=();created=1618884475;keyid="test-key-rsa-pss";alg="rsa-pss-sha512"`)
 	req.Header.Set("Signature", `sig1=:HWP69ZNiom9Obu1KIdqPPcu/C1a5ZUMBbqS/xwJECV8bhIQVmEAAAzz8LQPvtP1iFSxxluDO1KE9b8L+O64LEOvhwYdDctV5+E39Jy1eJiD7nYREBgxTpdUfzTO+Trath0vZdTylFlxK4H3l3s/cuFhnOCxmFYgEa+cw+StBRgY1JtafSFwNcZgLxVwialuH5VnqJS4JN8PHD91XLfkjMscTo4jmVMpFd3iLVe0hqVFl7MDt6TMkwIyVFnEZ7B/VIQofdShO+C/7MuupCSLVjQz5xA+Zs6Hw+W9ESD/6BuGs6LF1TcKLxW+5K+2zvDY/Cia34HNpRW5io7Iv9/b7iQ==:`)
 
-	err = v.Verify(req)
+	_, err = v.Verify(req)
 	if err != nil {
 		t.Error("verification failed:", err)
 	}
@@ -128,7 +128,7 @@ func TestVerify_B_2_2(t *testing.T) {
 	req.Header.Set("Signature-Input", `sig1=("@authority" content-type");created=1618884475;keyid="test-key-rsa-pss"`)
 	req.Header.Set("Signature", `sig1=:ik+OtGmM/kFqENDf9Plm8AmPtqtC7C9a+zYSaxr58b/E6h81ghJS3PcH+m1asiMp8yvccnO/RfaexnqanVB3C72WRNZN7skPTJmUVmoIeqZncdP2mlfxlLP6UbkrgYsk91NS6nwkKC6RRgLhBFqzP42oq8D2336OiQPDAo/04SxZt4Wx9nDGuy2SfZJUhsJqZyEWRk4204x7YEB3VxDAAlVgGt8ewilWbIKKTOKp3ymUeQIwptqYwv0l8mN404PPzRBTpB7+HpClyK4CNp+SVv46+6sHMfJU4taz10s/NoYRmYCGXyadzYYDj0BYnFdERB6NblI/AOWFGl5Axhhmjg==:`)
 
-	err = v.Verify(req)
+	_, err = v.Verify(req)
 	if err != nil {
 		t.Error("verification failed:", err)
 	}
@@ -160,7 +160,7 @@ func TestVerify_B_2_3(t *testing.T) {
 	req := testReq()
 	req.Header.Set("Signature-Input", `sig1=("date" "@method" "@path" "@query" "@authority" "content-type" "digest" "content-length");created=1618884475;keyid="test-key-rsa-pss"`)
 	req.Header.Set("Signature", `sig1=:JuJnJMFGD4HMysAGsfOY6N5ZTZUknsQUdClNG51VezDgPUOW03QMe74vbIdndKwW1BBrHOHR3NzKGYZJ7X3ur23FMCdANe4VmKb3Rc1Q/5YxOO8p7KoyfVa4uUcMk5jB9KAn1M1MbgBnqwZkRWsbv8ocCqrnD85Kavr73lx51k1/gU8w673WT/oBtxPtAn1eFjUyIKyA+XD7kYph82I+ahvm0pSgDPagu917SlqUjeaQaNnlZzO03Iy1RZ5XpgbNeDLCqSLuZFVID80EohC2CQ1cL5svjslrlCNstd2JCLmhjL7xV3NYXerLim4bqUQGRgDwNJRnqobpS6C1NBns/Q==:`)
-	err = v.Verify(req)
+	_, err = v.Verify(req)
 	if err != nil {
 		t.Error("verification failed:", err)
 	}
@@ -215,7 +215,7 @@ func TestVerify_B_2_5(t *testing.T) {
 	req.Header.Set("Signature-Input", `sig1=("@authority" "date" "content-type");created=1618884475;keyid="test-shared-secret"`)
 	req.Header.Set("Signature", `sig1=:fN3AMNGbx0V/cIEKkZOvLOoC3InI+lM2+gTv22x3ia8=:`)
 
-	err = v.Verify(req)
+	_, err = v.Verify(req)
 	if err != nil {
 		t.Error("verification failed:", err)
 	}

--- a/verify.go
+++ b/verify.go
@@ -171,9 +171,9 @@ func (v *verifier) ResolveKey(keyID string) (verHolder, bool) {
 	if v.resolver != nil {
 		key := v.resolver.Resolve(keyID)
 		if key != nil {
-			in := bytes.NewBuffer(make([]byte, 0, 1024))
 			holder := verHolder{
 				verifier: func() verImpl {
+					in := bytes.NewBuffer(make([]byte, 0, 1024))
 					return verImpl{
 						w: in,
 						verify: func(sig []byte) error {

--- a/verify.go
+++ b/verify.go
@@ -227,7 +227,6 @@ func verifyEccP256(pk *ecdsa.PublicKey) verHolder {
 }
 
 func verifyHmacSha256(secret []byte) verHolder {
-	// TODO: add alg
 	return verHolder{
 		alg: "hmac-sha256",
 		verifier: func() verImpl {


### PR DESCRIPTION
Current transport/middleware design works well with native Go HTTP libraries. However, if I want to use some modern HTTP libraries like gin-gonic or resty, the user experience becomes a disaster. I have to clone `*http.Request` over and over and do a lot of dirty magic to prevent the middleware from corrupting my `*gin.Context`.

Thus I propose this Verifier/Signer interface, which gives more control for us to plug-in them to other HTTP frameworks.

Moreover, if I'm maintaining tens of thousands of crypto keys, it's impossible to pass them one by one when initializing a verifier. Thus I propose a `VerifyingKeyResolver` interface, so that the verifier can search a database by itself.